### PR TITLE
Collect cpuacct.usage for mesos cgroup

### DIFF
--- a/src/collectors/mesos_cgroup/mesos_cgroup.py
+++ b/src/collectors/mesos_cgroup/mesos_cgroup.py
@@ -94,8 +94,9 @@ class MesosCGroupCollector(diamond.collector.Collector):
         state = self.get_mesos_state()
 
         containers = {
-            'options': ''
+            'flags': state['flags']
         }
+
         if 'frameworks' in state:
             for framework in state['frameworks']:
                 for executor in framework['executors']:

--- a/src/collectors/mesos_cgroup/mesos_cgroup.py
+++ b/src/collectors/mesos_cgroup/mesos_cgroup.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+
+"""
+Collects Mesos Task cgroup statistics. Because Mesos Tasks
+only tangentially relate to the host they are running on,
+this collector uses task 'source' information to build the
+naming path. The prefix is overridden in the collector to
+place metrics in the graphite tree at the root under
+`mesos.tasks`. The container ID contained within the
+source string will serve as the container uniqueifier.
+
+If your scheduler (this was written against a Mesos cluster
+    being scheduled by Aurora) does not include uniqueifing
+information in the task data under `frameworks.executors.source`,
+you're going to have a bad time.
+
+#### Example Configuration
+
+```
+    host = localhost
+    port = 5051
+```
+"""
+
+import diamond.collector
+import json
+import urllib2
+import os
+
+
+class MesosCGroupCollector(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        config_help = super(MesosCGroupCollector,
+                            self).get_default_config_help()
+        config_help.update({
+            'host': 'Hostname',
+            'port': 'Port'
+        })
+        return config_help
+
+    def get_default_config(self):
+        # https://github.com/BrightcoveOS/Diamond/blob/master/src/diamond/collector.py#L312-L358
+        config = super(MesosCGroupCollector, self).get_default_config()
+        config.update({
+            'mesos_state_path': 'state.json',
+            'cgroup_fs_path': '/sys/fs/cgroup',
+            'host': 'localhost',
+            'port': 5051,
+            'path_prefix': 'mesos',
+            'path': 'tasks',
+            'hostname': None
+        })
+        return config
+
+    def __init__(self, *args, **kwargs):
+        super(MesosCGroupCollector, self).__init__(*args, **kwargs)
+
+    def collect(self):
+        containers = self.get_containers()
+
+        sysfs = containers['flags']['cgroups_hierarchy']
+        cgroup_root = containers['flags']['cgroups_root']
+
+        for aspect in ['cpuacct', 'cpu', 'memory']:
+            aspect_path = os.path.join(sysfs, aspect, cgroup_root)
+
+            contents = os.listdir(aspect_path)
+            for task_id in [entry for entry in contents if
+                            os.path.isdir(os.path.join(aspect_path, entry))]:
+
+                if task_id not in containers:
+                    continue
+
+                key_parts = [containers[task_id]['environment'],
+                             containers[task_id]['role'],
+                             containers[task_id]['task'],
+                             containers[task_id]['id'],
+                             aspect]
+
+                # list task_id items
+                task_id = os.path.join(aspect_path, task_id)
+
+                with open(os.path.join(task_id, "%s.stat" % aspect)) as f:
+                    data = f.readlines()
+
+                    for kv_pair in data:
+                        key, value = kv_pair.split()
+                        self.publish(
+                            self.clean_up(
+                                '.'.join(key_parts + [key])), value)
+
+    def get_containers(self):
+        state = self.get_mesos_state()
+
+        containers = {
+            'options': ''
+        }
+        if 'frameworks' in state:
+            for framework in state['frameworks']:
+                for executor in framework['executors']:
+                    container = executor['container']
+                    source = executor['source']
+                    role, environment, task, number = source.split('.')
+
+                    containers[container] = {'role': role,
+                                             'environment': environment,
+                                             'task': task,
+                                             'id': number
+                                             }
+
+        return containers
+
+    def get_mesos_state(self):
+        try:
+            url = "http://%s:%s/%s" % (self.config['host'],
+                                       self.config['port'],
+                                       self.config['mesos_state_path'])
+
+            return json.load(urllib2.urlopen(url))
+        except (urllib2.HTTPError, ValueError), err:
+            self.log.error('Unable to read JSON response: %s' % err)
+            return {}
+
+    def clean_up(self, text):
+        return text.replace('/', '.')

--- a/src/collectors/mesos_cgroup/test/fixtures/state.json
+++ b/src/collectors/mesos_cgroup/test/fixtures/state.json
@@ -1,0 +1,136 @@
+{
+  "attributes": {
+    "host": "mesos-worker101.example.local",
+    "instance_id": "i-asdf",
+    "instance_type": "c3.4xlarge",
+    "rack": "us-east-1c"
+  },
+  "build_date": "2015-07-24 10:05:39",
+  "build_time": 1437732339,
+  "build_user": "root",
+  "completed_frameworks": [],
+  "flags": {
+    "attributes": "host:mesos-worker101.example.local;rack:us-east-1c;instance_id:asdf;instance_type:c3.4xlarge",
+    "authenticatee": "crammd5",
+    "cgroups_cpu_enable_pids_and_tids_count": "false",
+    "cgroups_enable_cfs": "false",
+    "cgroups_hierarchy": "/sys/fs/cgroup",
+    "cgroups_limit_swap": "false",
+    "cgroups_root": "mesos",
+    "container_disk_watch_interval": "15secs",
+    "containerizers": "mesos",
+    "default_role": "*",
+    "disk_watch_interval": "1mins",
+    "docker": "docker",
+    "docker_kill_orphans": "true",
+    "docker_remove_delay": "6hrs",
+    "docker_sandbox_directory": "/mnt/mesos/sandbox",
+    "docker_socket": "/var/run/docker.sock",
+    "docker_stop_timeout": "0ns",
+    "enforce_container_disk_quota": "false",
+    "executor_registration_timeout": "1mins",
+    "executor_shutdown_grace_period": "5secs",
+    "fetcher_cache_dir": "/tmp/mesos/fetch",
+    "fetcher_cache_size": "2GB",
+    "frameworks_home": "",
+    "gc_delay": "1weeks",
+    "gc_disk_headroom": "0.1",
+    "hadoop_home": "",
+    "help": "false",
+    "hostname": "mesos-worker101.example.local",
+    "initialize_driver_logging": "true",
+    "ip": "10.113.197.14",
+    "isolation": "cgroups/cpu,cgroups/mem",
+    "launcher_dir": "/usr/libexec/mesos",
+    "log_dir": "/var/log/mesos",
+    "logbufsecs": "0",
+    "logging_level": "INFO",
+    "master": "zk",
+    "oversubscribed_resources_interval": "15secs",
+    "perf_duration": "10secs",
+    "perf_interval": "1mins",
+    "port": "5051",
+    "qos_correction_interval_min": "0ns",
+    "quiet": "false",
+    "recover": "reconnect",
+    "recovery_timeout": "15mins",
+    "registration_backoff_factor": "1secs",
+    "resource_monitoring_interval": "1secs",
+    "resources": "cpus:16",
+    "revocable_cpu_low_priority": "true",
+    "strict": "true",
+    "switch_user": "true",
+    "version": "false",
+    "work_dir": "/mnt/mesos"
+  },
+  "frameworks": [
+    {
+      "checkpoint": true,
+      "executors": [
+        {
+          "completed_tasks": [],
+          "container": "b0d5971e-915c-414b-aa25-0da46e64ff4e",
+          "directory": "/mnt/mesos/slaves/20150729-213810-1276885514-5050-21492-S31/frameworks/20150507-194526-3627858186-5050-8132-0000/executors/thermos-1442505224463-ROLE-ENVIRONMENT-TASK-0-0c145f91-d46f-4089-a57e-3ccd89e49c36/runs/b0d5971e-915c-414b-aa25-0da46e64ff4e",
+          "id": "thermos-1442505224463-ROLE-ENVIRONMENT-TASK-0-0c145f91-d46f-4089-a57e-3ccd89e49c36",
+          "name": "aurora.task",
+          "queued_tasks": [],
+          "resources": {
+            "cpus": 0.5,
+            "disk": 14336,
+            "mem": 5920,
+            "ports": "[31130-31130, 31163-31163, 31656-31656, 31707-31707]"
+          },
+          "source": "ROLE.ENVIRONMENT.TASK.0",
+          "tasks": [
+            {
+              "executor_id": "thermos-1442505224463-ROLE-ENVIRONMENT-TASK-0-0c145f91-d46f-4089-a57e-3ccd89e49c36",
+              "framework_id": "20150507-194526-3627858186-5050-8132-0000",
+              "id": "1442505224463-ROLE-ENVIRONMENT-TASK-0-0c145f91-d46f-4089-a57e-3ccd89e49c36",
+              "labels": [],
+              "name": "ROLE/ENVIRONMENT/TASK",
+              "resources": {
+                "cpus": 0.49,
+                "disk": 14335,
+                "mem": 5888,
+                "ports": "[31130-31130, 31163-31163, 31656-31656, 31707-31707]"
+              },
+              "slave_id": "20150729-213810-1276885514-5050-21492-S31",
+              "state": "TASK_RUNNING",
+              "statuses": [
+                {
+                  "state": "TASK_STARTING",
+                  "timestamp": 1442505225.13683
+                },
+                {
+                  "state": "TASK_RUNNING",
+                  "timestamp": 1442505226.43909
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "failover_timeout": 1814400,
+      "hostname": "mesos-master101",
+      "id": "20150507-194526-3627858186-5050-8132-0000",
+      "name": "TwitterScheduler",
+      "role": "*",
+      "user": "root"
+    }
+  ],
+  "git_sha": "4ce5475346a0abb7ef4b7ffc9836c5836d7c7a66",
+  "git_tag": "0.23.0",
+  "hostname": "mesos-worker101.example.local",
+  "id": "20150729-213810-1276885514-5050-21492-S31",
+  "log_dir": "/var/log/mesos",
+  "master_hostname": "ip-10-11-132-141.ec2.internal",
+  "pid": "slave(1)@10.113.197.14:5051",
+  "resources": {
+    "cpus": 16,
+    "disk": 302319,
+    "mem": 29124,
+    "ports": "[31000-32000]"
+  },
+  "start_time": 1442854419.06138,
+  "version": "0.23.0"
+}

--- a/src/collectors/mesos_cgroup/test/testmesos_cgroup.py
+++ b/src/collectors/mesos_cgroup/test/testmesos_cgroup.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# coding=utf-8
+##########################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import patch
+
+from diamond.collector import Collector
+
+from mesos import MesosCollector
+
+##########################################################################
+
+
+class TestMesosCollector(CollectorTestCase):
+
+    def setUp(self):
+        config = get_collector_config('MesosCollector', {})
+
+        self.collector = MesosCollector(config, None)
+
+    def test_import(self):
+        self.assertTrue(MesosCollector)
+
+    @patch.object(Collector, 'publish')
+    def test_should_work_with_real_data(self, publish_mock):
+        def se(url):
+            if url == 'http://localhost:5051/state.json':
+                return self.getFixture('state.json')
+
+        patch_urlopen = patch('urllib2.urlopen', Mock(side_effect=se))
+
+        patch_urlopen.start()
+        self.collector.collect()
+        patch_urlopen.stop()
+
+        metrics = self.valid_metrics()
+        self.setDocExample(collector=self.collector.__class__.__name__,
+                           metrics=metrics,
+                           defaultpath=self.collector.config['path'])
+        self.assertPublishedMany(publish_mock, metrics)
+
+    def valid_metrics(self):
+        return {
+            'master.cpus_percent': 0.762166666666667,
+            'master.cpus_total': 120,
+            'master.cpus_used': 91.46,
+            'master.disk_percent': 0.0317975447795468,
+            'master.disk_total': 12541440,
+            'master.disk_used': 398787
+        }
+
+##########################################################################
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There is a bug in ubuntu that causes significant drift between cpuacct.usage and cpuacct.stats (https://bugs.launchpad.net/ubuntu/+source/linux-lts-trusty/+bug/1497447). This changes adds the collection of cpuacct.usage because it more accurately reflects how much cpu time has actually been used.
